### PR TITLE
Buildpack causes error when credentials include Fixnum

### DIFF
--- a/lib/0001_retrieve-secrets.sh
+++ b/lib/0001_retrieve-secrets.sh
@@ -77,7 +77,7 @@ def generate_vcap_creds_hash
     exit(1)
   end
 
-  @creds_map.reject! { |key, _| creds[key.to_s].empty? }
+  @creds_map.reject! { |key, _| creds[key.to_s].to_s.empty? }
 
   Hash[ @creds_map.map { |key, env_var_name| [ env_var_name, creds[key.to_s].to_s ] } ]
 end


### PR DESCRIPTION
If the `credentials` in `VCAP_SERVICES` includes a value of type Fixnum, then the line of code that checks for blank credentials and excludes them from the environment variables passed to Summon will error.

This PR fixes that line of code so it will convert the value to a string before checking if it is empty.

[Jenkins build](https://jenkins.conjur.net/job/cyberark--cloudfoundry-conjur-buildpack/job/fixnum-blank-var-bug-fix/1/)
