### PR TITLE
Update supply script to use correct profile directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The CyberArk Conjur Buildpack is a [supply buildpack](https://docs.cloudfoundry.org/buildpacks/custom.html#contract) that provides convenient and secure access to secrets stored in Conjur.
+The CyberArk Conjur Buildpack is a [supply buildpack](https://docs.cloudfoundry.org/buildpacks/understand-buildpacks.html#supply-script) that installs scripts to provide convenient and secure access to secrets stored in Conjur.
 
 The buildpack supplies scripts to your application that do the following:
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,21 @@ SSL_CERT: /tmp/ssl-cert.pem
 
 When you deploy your application, ensure it is bound to a Conjur service instance and add the Conjur Buildpack to your `cf push` command:
 
+```sh
+cf push my-app -b conjur_buildpack ... -b final_buildpack
 ```
-cf push my-app -b conjur-buildpack -b final-buildpack
+
+Alternatively, the buildpacks may be specified in the application manifest, for example:
+
+```yaml
+---
+applications:
+- name: my-app
+  services:
+  - conjur
+  buildpacks:
+  - conjur_buildpack
+  - ruby_buildpack
 ```
 
 When your application starts, the Conjur Buildpack will inject the secrets specified in the `secrets.yml` file into the application process as environment variables.

--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ The buildpack supplies scripts to your application that do the following:
 
 + Your app must have a `secrets.yml` file in its root directory when deployed
 
-## How Does the Buildpack Work ?
+## How Does the Buildpack Work?
 
-The buildpack uses a [supply script](https://docs.cloudfoundry.org/buildpacks/understand-buildpacks.html#supply-script) to copy files into the application's dependency directory under a subdirectory corresponding to the buildpack's index. The `lib/0001_retrieve-secrets.sh` script is copied into a `.profile.d` subdirectory so that it will run automatically when the app starts and the `conjur-env` binary is copied to a `vendor` subdirectory. In other words, your application will end up with the following two files:
+The buildpack uses a [supply script](https://docs.cloudfoundry.org/buildpacks/understand-buildpacks.html#supply-script) to copy files into the application's dependency directory under a subdirectory corresponding to the buildpack's index. The `lib/0001_retrieve-secrets.sh` script is copied into a `profile.d` subdirectory so that it will run automatically when the app starts and the `conjur-env` binary is copied to a `vendor` subdirectory. In other words, your application will end up with the following two files:
 
 ```
-- $DEPS_DIR/$BUILDPACK_INDEX/.profile.d/0001-retrieve-secrets.sh
+- $DEPS_DIR/$BUILDPACK_INDEX/profile.d/0001-retrieve-secrets.sh
 - $DEPS_DIR/$BUILDPACK_INDEX/vendor/conjur-env
 ```
 
-The `.profile.d` script is run automatically when the application starts and is responsible for retrieving secrets and injecting them into the app's session environment variables.
+The `profile.d` script is run automatically when the application starts and is responsible for retrieving secrets and injecting them into the app's session environment variables.
 
 The `conjur-env` binary leverages the [Conjur Go API](https://github.com/cyberark/conjur-api-go) and [Summon](https://github.com/cyberark/summon)
 to authenticate with Conjur and retrieve secrets.

--- a/bin/supply
+++ b/bin/supply
@@ -27,15 +27,15 @@ if [[ false = $(echo $VCAP_SERVICES | jq 'has("cyberark-conjur")') ]]; then
 fi
 
 pushd ${DEPS_DIR}/${INDEX_DIR}
-  # We add the lib/0001_retrieve-secrets.sh script to .profile.d so that it will
+  # We add the lib/0001_retrieve-secrets.sh script to profile.d so that it will
   # be run automatically to retrieve secrets when the app starts.
-  mkdir -p .profile.d
-  cp ${BUILDPACK_DIR}/lib/0001_retrieve-secrets.sh ./.profile.d/0001_retrieve-secrets.sh
-  sed "s/__BUILDPACK_INDEX__/$INDEX_DIR/g" ./.profile.d/0001_retrieve-secrets.sh -i
+  mkdir -p profile.d
+  cp ${BUILDPACK_DIR}/lib/0001_retrieve-secrets.sh ./profile.d/0001_retrieve-secrets.sh
+  sed "s/__BUILDPACK_INDEX__/$INDEX_DIR/g" ./profile.d/0001_retrieve-secrets.sh -i
 
   # conjur-env reads a secrets.yml file and uses it to retrieve secrets from
   # Conjur. We copy it to the dependency directory to make it accessible to the
-  # /.profile.d script. The /vendor subdirectory is just for convenience.
+  # /profile.d script. The /vendor subdirectory is just for convenience.
   mkdir -p vendor
   cp ${BUILDPACK_DIR}/vendor/conjur-env ./vendor/conjur-env
 popd

--- a/ci/features/profile_d.feature
+++ b/ci/features/profile_d.feature
@@ -28,7 +28,7 @@ Feature: profile d script
     CONJUR_MULTI_LINE_SECRET: !var conjur_multi_line_secret_id
     LITERAL_SECRET: some literal secret
     """
-    When the retrieve secrets .profile.d script is sourced
+    When the retrieve secrets profile.d script is sourced
     And the 'env' command is run
     Then the environment contains
     """

--- a/ci/features/step_definitions/profile_d_steps.rb
+++ b/ci/features/step_definitions/profile_d_steps.rb
@@ -1,10 +1,10 @@
-When(/^the retrieve secrets \.profile\.d script is sourced$/) do
+When(/^the retrieve secrets profile\.d script is sourced$/) do
   @commands ||= []
 
   # Set $HOME and $DEPS_DIR to mimic variables that are made available to the
   # script when run normally via profile.d.
   @commands << <<EOL
-HOME=#{@BUILD_DIR} DEPS_DIR=#{@DEPS_DIR} . #{@DEPS_DIR}/#{@INDEX_DIR}/.profile.d/0001_retrieve-secrets.sh
+HOME=#{@BUILD_DIR} DEPS_DIR=#{@DEPS_DIR} . #{@DEPS_DIR}/#{@INDEX_DIR}/profile.d/0001_retrieve-secrets.sh
 EOL
 end
 

--- a/ci/features/step_definitions/supply_steps.rb
+++ b/ci/features/step_definitions/supply_steps.rb
@@ -3,6 +3,6 @@ Then(/^conjur-env is installed$/) do
   expect($?.exitstatus).to eq (0)
 end
 
-Then(/^the retrieve secrets \.profile\.d script is installed$/) do
-  expect(File.exist?("#{@DEPS_DIR}/#{@INDEX_DIR}/.profile.d/0001_retrieve-secrets.sh")).to be_truthy
+Then(/^the retrieve secrets profile\.d script is installed$/) do
+  expect(File.exist?("#{@DEPS_DIR}/#{@INDEX_DIR}/profile.d/0001_retrieve-secrets.sh")).to be_truthy
 end

--- a/ci/features/supply.feature
+++ b/ci/features/supply.feature
@@ -1,14 +1,14 @@
 Feature: Supply script
-  Supply script installs conjur-env and .profile.d script
+  Supply script installs conjur-env and profile.d script
 
   @BUILD_DIR
-  Scenario: Successfully installs conjur-env and .profile.d scripts
+  Scenario: Successfully installs conjur-env and profile.d scripts
     Given the build directory has a secrets.yml file
     And VCAP_SERVICES contains cyberark-conjur credentials
     When the supply script is run against the app's root folder
     Then the result should have a 0 exit status
     And conjur-env is installed
-    And the retrieve secrets .profile.d script is installed
+    And the retrieve secrets profile.d script is installed
 
   @BUILD_DIR
   Scenario: When the app does not have a secrets.yml file


### PR DESCRIPTION
Connected to #22 

This PR updates the Conjur buildpack to install the secret retrieval script into `profile.d` instead of `.profile.d`.

It also updates the README to improve the examples for using the buildpack.

Jenkins build: https://jenkins.conjur.net/job/cyberark--cloudfoundry-conjur-buildpack/job/22-supply-profile-dir/