### PR TITLE
Fetch CI environment URLs via summon

### DIFF
--- a/secrets.yml
+++ b/secrets.yml
@@ -1,2 +1,2 @@
-CF_API_ENDPOINT: https://api.sys.pcf.itd.conjur.net
+CF_API_ENDPOINT: !var ci/pcf/api-url
 CF_ADMIN_PASSWORD: !var ci/pcf/admin-cli-password


### PR DESCRIPTION
Connected to https://github.com/conjurinc/cloudfoundry-conjur-tile/issues/32

This PR removes the CI environment URLs from `secrets.yml` and pulls them via Summon as well.