### PR TITLE
Downgrade CF CLI version used in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,12 @@ pipeline {
   }
 
   stages {
+    stage('Grant IP Access') {
+      steps {
+        // Grant access to this Jenkins agent's IP to AWS security groups
+        grantIPAccess()
+      }
+    }
     stage('Validate') {
       parallel {
         stage('Changelog') {
@@ -41,6 +47,8 @@ pipeline {
   post {
     always {
       cleanupAndNotify(currentBuild.currentResult)
+      // Remove this Jenkins Agent's IP from AWS security groups
+      removeIPAccess()
     }
   }
 }

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
 
 # Install a specific older version, since our remote foundation currently uses
 # TAS 2.4
-RUN curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.52.0&source=github-rel" | tar -zx && \
+RUN curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.51.0&source=github-rel" | tar -zx && \
     mv cf /usr/local/bin && \
 
     mkdir -p "$CI_PATH" && \

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -12,11 +12,10 @@ RUN apt-get update && \
                        openssl \
                        ruby2.5-dev
 
-RUN wget -q https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key && \
-    apt-key add cli.cloudfoundry.org.key && \
-    echo "deb https://packages.cloudfoundry.org/debian stable main" > /etc/apt/sources.list.d/cloudfoundry-cli.list && \
-    apt-get update && \
-    apt-get install -y cf-cli && \
+# Install a specific older version, since our remote foundation currently uses
+# TAS 2.4
+RUN curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.52.0&source=github-rel" | tar -zx && \
+    mv cf /usr/local/bin && \
 
     mkdir -p "$CI_PATH" && \
 


### PR DESCRIPTION
### What does this PR do?
Our CI foundation is currently using TAS 2.4, which is an older version. The
CF CLI has continued to release new versions, and now the newest releases are
no longer compatible with our older foundation. We have work scheduled to
update our remote foundation, but until then we need to continue using a CF
CLI version that is compatible with our deployed CF API. This commit hardcodes
the CF CLI version that we use in our CI pipelines for this project, for now.

### What ticket does this PR close?
Partially resolves https://github.com/cyberark/conjur-service-broker/issues/202

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation