### PR TITLE
Update to add IP to list for security group access

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,12 @@ pipeline {
   }
 
   stages {
+    stage('Grant IP Access') {
+      steps {
+        // Grant access to this Jenkins agent's IP to AWS security groups
+        grantIPAccess()
+      }
+    }
     stage('Validate') {
       parallel {
         stage('Changelog') {
@@ -41,6 +47,8 @@ pipeline {
   post {
     always {
       cleanupAndNotify(currentBuild.currentResult)
+      // Remove this Jenkins Agent's IP from AWS security groups
+      removeIPAccess()
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
This uses new pipeline library functions to add the IP address of the Jenkins agent to the
AWS prefix list used to limit access to the PCF cluster and remove access once completed.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation