### PR TITLE
Update actions/setup-go to use v2

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Set up Go 1.13
-      uses: actions/setup-go@v2.0.1
+      uses: actions/setup-go@v2
       with:
         go-version: 1.13
       id: go


### PR DESCRIPTION
### What does this PR do?

Updates actions/setup-go to use v2, used in running unit tests via Github Actions. Some commands have been deprecated in Github actions, see https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/, v2 addresses this.

### What ticket does this PR close?
N/A

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation