### PR TITLE
Bump bundler version in ci Dockerfile

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -20,8 +20,9 @@ RUN wget -q https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key &&
     apt-get install -y cf-cli
 
 # Install ruby dependencies
-RUN mkdir -p "$CI_PATH" && \
-    gem install bundler && \
+RUN gem update --system && \
+    mkdir -p "$CI_PATH" && \
+    gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)" && \
     # This will prevent warnings about installing gems as root
     bundle config --global silence_root_warning 1
 


### PR DESCRIPTION
### What does this PR do?
Fixes buildpack issue, as seen here:
https://bundler.io/blog/2019/05/14/solutions-for-cant-find-gem-bundler-with-executable-bundle.html

### What ticket does this PR close?
-

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation