### PR TITLE
Update recommendations for online buildpack usage

### DIFF
--- a/.github/workflows/copy-release-to-latest-branch.yml
+++ b/.github/workflows/copy-release-to-latest-branch.yml
@@ -1,0 +1,54 @@
+name: Copy Releases to Latest Branch
+on:
+  push:
+    # We trigger this workflow on tag pushes that match v* (eg. `v1.2.3`)
+    tags:
+      - 'v*'
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  copy-release-branch-to-latest:
+    name: Copy Release Branch to Latest
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+      with:
+        ref: master
+
+    - name: Configure Git
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+
+    - name: Set variables
+      run: |
+        tag_name=$(echo "${GITHUB_REF#refs/tags/}")
+
+        echo "::set-output name=TAG_NAME::${tag_name}"
+        echo "Tag: ${tag_name}"
+
+        branch_name=$(echo "update-latest-with-${tag_name}")
+        echo "::set-output name=UPDATE_BRANCH::${branch_name}"
+      id: data
+
+    - name: Checkout repo
+      uses: actions/checkout@v2
+      with:
+        ref: "${{ steps.data.outputs.TAG_NAME }}"
+
+    - name: Copy the tag code to a branch
+      run: |
+        git push --force "https://${{ github.actor }}:${{secrets.GITHUB_TOKEN}}@github.com/${{ github.repository }}.git" "HEAD:refs/heads/${{ steps.data.outputs.UPDATE_BRANCH }}"
+
+    - name: Open a PR to archive the tag in the latest branch
+      uses: vsoch/pull-request-action@d987bc1 # Pinned v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PULL_REQUEST_FROM_BRANCH: "${{ steps.data.outputs.UPDATE_BRANCH }}"
+        PULL_REQUEST_BRANCH: latest
+        PULL_REQUEST_TITLE: "Action: Update latest branch for ${{ steps.data.outputs.TAG_NAME }}"
+        PULL_REQUEST_BODY: "Auto-generated PR!"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The default go version has been bumped to `1.15.x` in the manifest,
   with other supported version listed as well.
   [cyberark/cloudfoundry-conjur-buildpack#41](https://github.com/cyberark/cloudfoundry-conjur-buildpack/issues/41)
+- Release tags will now be auto-archived in the `latest` branch. Users
+  consuming this buildpack via the online buildpack functionality should now
+  point their manifests to the `latest` branch and only consume release versions
+  of this buildpack.
+  [cyberark/cloudfoundry-conjur-buildpack#101](https://github.com/cyberark/cloudfoundry-conjur-buildpack/issues/101)
 
 ### Deprecated
 - Support for using the Conjur Buildpack with Conjur Enterprise v4 is now deprecated.

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ repository address instead of specifying the installed buildpack name. This may
 be done with the `cf push` command or using the manifest file.
 
 ```sh
-cf push my-app -b https://github.com/cyberark/cloudfoundry-conjur-buildpack ... -b final_buildpack
+cf push my-app -b https://github.com/cyberark/cloudfoundry-conjur-buildpack#latest ... -b final_buildpack
 ```
 
 ```yaml
@@ -216,8 +216,16 @@ applications:
   services:
   - conjur
   buildpacks:
-  - https://github.com/cyberark/cloudfoundry-conjur-buildpack
+  - https://github.com/cyberark/cloudfoundry-conjur-buildpack#latest
   - ruby_buildpack
+```
+
+We recommend users specifically reference the `latest` branch when using the
+online version of the buildpack. The `latest` branch is up-to-date with the
+latest tagged buildpack release. You may also opt to reference a specific
+release version `TAG` by referring to the online buildpack as:
+```
+https://github.com/cyberark/cloudfoundry-conjur-buildpack#TAG
 ```
 
 ## Contributing


### PR DESCRIPTION
### What does this PR do?
- Add automation to auto-archive tags in the latest branch
- Update README to recommend users refer to the latest branch or a specific tag
  when using the online buildpack functionality

To see how the action works in action, you can review this [test run](https://github.com/conjurinc/playroom/actions/runs/472382983) that resulted in a [PR being opened](https://github.com/conjurinc/playroom/pull/154) post-tag.

### What ticket does this PR close?
Resolves #101

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation