### PR TITLE
Removes support for Conjur Enterprise v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+- Support for using the Buildpack with Conjur Enterprise v4. We recommend
+  users migrate to Dynamic Access Provider v11+ or Conjur OSS v1+.
+  [cyberark/cloudfoundry-conjur-buildpack#86](https://github.com/cyberark/cloudfoundry-conjur-buildpack/issues/86)
+
 ## [2.1.6] - 2020-01-11
 ### Added
 - A [`manifest.yml`](./manifest.yml) has been added, allowing for


### PR DESCRIPTION
### What does this PR do?

This change adds a `Removed` entry to the CHANGELOG.md to indicate
that support for using the buildpack with Conjur v4 is no longer
available.

No code changes are required to remove Conjur v4 support since the
code and tests are largely agnostic of which Conjur version it is
working with. The conjur-dev code and the tests use:
- cyberark/conjur latest Docker image
- cyberark/conjur-api-go v0.6.0
- cyberark/summon v0.8.2 (secretsyml module)

There is one location where the credentials for the Conjur API is
set for Conjur v5:
tests/integration/features/step_definitions/common_steps.rb, line 59.

### What ticket does this PR close?
Resolves #86 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation