### PR TITLE
Remove 'rm' lines in secret retrieval start script

### DIFF
--- a/tests/retrieve-secrets/start
+++ b/tests/retrieve-secrets/start
@@ -6,8 +6,7 @@ cd $(dirname $0)
 
 echo "Building mock-conjur-env..."
 
-[ -d "temp_clone_dir" ] && rm -rf "temp_clone_dir"
-mkdir temp_clone_dir
+mkdir -p temp_clone_dir
 git clone https://github.com/ztombol/bats-support temp_clone_dir/bats-support
 git clone https://github.com/ztombol/bats-assert temp_clone_dir/bats-assert
 


### PR DESCRIPTION
### What does this PR do?
We ran into a small race condition when deleting the BATS dependencies before downloading them.
Thus, we've removed those lines, since they don't need to be removed from an empty environment before
we run the script.

### What ticket does this PR close?
Resolves #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation