### PR TITLE
Add support for summon evironments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- The `secrets.yml` can now be configured with multiple environment values,
+  allowing the separation of secrets into different "environments" which
+  can be specified through the `manifest.yml` for your deployment. You can
+  find more information in the [README](./README.md#using-environments-in-your-secretsyml).
+  [cyberark/cloudfoundry-conjur-buildpack#44](https://github.com/cyberark/cloudfoundry-conjur-buildpack/issues/44)
 
 ### Removed
 - Support for using the Buildpack with Conjur Enterprise v4. We recommend

--- a/README.md
+++ b/README.md
@@ -164,6 +164,52 @@ $ cf set-env {Application Name} SECRETS_YAML_PATH {Relative Path to secrets.yml}
 $ cf restage {Application Name}
 ```
 
+##### Using environments in your secrets.yml
+
+One can specify which environment/section to parse from the
+secrets YAML file. In addition, it will also enable the usage of a `common`
+(or `default`) section which will be inherited by other sections/environments.
+In other words, if your secrets.yaml looks something like this:
+
+```yaml
+common:
+  DB_USER: path/to/usernamr
+  DB_NAME: db-name
+  DB_HOST: path/to/host_url
+
+staging:
+  DB_PASS: /path/to/staging_password
+
+production:
+  DB_PASS: path/to/prod_password
+```
+
+You can specify the following in your manifest:
+
+```yaml
+---
+applications:
+- name: my-app
+  services:
+  - conjur
+  buildpacks:
+  - conjur_buildpack
+  - php_buildpack
+  env:
+    SECRETS_YAML_PATH: lib/secrets.yml
+    SECRETS_ENV: staging
+```
+
+With this configuration, the following environment variables would be
+available in the environment:
+
+```shell
+  DB_USER: db-user
+  DB_NAME: db-name
+  DB_HOST: db-host.example.com
+  DB_PASS: staging_password
+```
+
 #### Invoke the Installed Buildpack at Deploy Time
 
 When you deploy your application, ensure it is bound to a Conjur service instance

--- a/conjur-env/main.go
+++ b/conjur-env/main.go
@@ -111,9 +111,13 @@ func main() {
 	if !exists {
 		secretsYamlPath = "secrets.yml"
 	}
+	secretsEnv, exists := os.LookupEnv("SECRETS_ENV")
+	if !exists {
+		secretsEnv = ""
+	}
 
 	// Parse the secrets YAML file.
-	secrets, err := parseSecretsYamlFile(secretsYamlPath)
+	secrets, err := parseSecretsYamlFile(secretsYamlPath, secretsEnv)
 	printAndExitIfError(err)
 
 	// Confirm that environment variable names parsed from the secrets YAML
@@ -136,8 +140,8 @@ func main() {
 // parseSecretsYamlFile parses a secrets YAML file at a specified path
 // and returns an error if either the file doesn't exist or it contains
 // invalid secrets YAML syntax.
-func parseSecretsYamlFile(secretsYamlPath string) (secretsyml.SecretsMap, error) {
-	secrets, err := secretsyml.ParseFromFile(secretsYamlPath, "", nil)
+func parseSecretsYamlFile(secretsYamlPath string, env string) (secretsyml.SecretsMap, error) {
+	secrets, err := secretsyml.ParseFromFile(secretsYamlPath, env, nil)
 	if os.IsNotExist(err) {
 		err = fmt.Errorf("error: %s not found", secretsYamlPath)
 	}

--- a/tests/integration/apps/php/manifest-env.yml.template
+++ b/tests/integration/apps/php/manifest-env.yml.template
@@ -1,0 +1,10 @@
+---
+applications:
+- name: php-app
+  env:
+    CONJUR_BUILDPACK_BYPASS_SERVICE_CHECK: true
+    SECRETS_YAML_PATH: lib/secrets.yml
+    SECRETS_ENV: staging
+  buildpacks:
+  - {conjur_buildpack}
+  - php_buildpack

--- a/tests/integration/features/profile_d.feature
+++ b/tests/integration/features/profile_d.feature
@@ -46,3 +46,44 @@ Feature: profile d script
     second line
 
     """
+
+  @BUILD_DIR
+  Scenario: Populates only the secrets for a given Summon environment
+    Given the build directory has a secrets.yml file
+    And VCAP_SERVICES contains cyberark-conjur credentials
+    And the supply script is run against the app's root folder
+    And conjur-env is installed
+    And a root policy:
+    """
+    - !variable conjur_single_line_secret_id
+    """
+    And the 'conjur_single_line_secret_id' variable has a secret value
+    """
+    single line
+    """
+    And VCAP_SERVICES contains cyberark-conjur credentials
+    And the build directory has this secrets.yml file
+    """
+    common:
+        LITERAL_SECRET: some literal secret
+
+    dev:
+        CONJUR_SINGLE_LINE_SECRET: !var conjur_single_line_secret_id
+
+    prod:
+        CONJUR_SINGLE_LINE_SECRET: production_secret
+    """
+    And The SECRETS_ENV value is 'dev'
+    When the retrieve secrets profile.d script is sourced
+    And the 'env' command is run
+    Then the environment contains
+    """
+    LITERAL_SECRET=some literal secret
+
+    """
+
+    And the environment contains
+    """
+    CONJUR_SINGLE_LINE_SECRET=single line
+
+    """

--- a/tests/integration/features/support/cf_helper.rb
+++ b/tests/integration/features/support/cf_helper.rb
@@ -28,7 +28,7 @@ module CfHelper
 
     res.body.strip
   end
-  
+
   def login_to_pcf
     api_endpoint = ENV['CF_API_ENDPOINT']
 


### PR DESCRIPTION
### What does this PR do?
`SUMMON_ENV` is now a configurable variable in buildpack
manifests, allowing the user to define multiple environments in their
`secrets.yml`. This allows for configurable deployments using the same
`secrets.yml` file.

Note: Rubocop requests we use "meaningful" heredoc labels, e.g. anything other than EOS

### What ticket does this PR close?
Resolves #44 

### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [X] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [X] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation