### PR TITLE
Update links in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.1.6] - 2020-01-11
 ### Added
-- A [`manifest.yml`](./manifest.yml) has been added, allowing for
-  the usage of [buildpack-packager](https://github.com/cloudfoundry/buildpack-packager)
-  and other native CloudFoundry features. Please refer
-  to [`manifest.yml`](./manifest.yml) for information on
-  dependencies and deprecation notices thereof, as well as a list
-  of files included in the Buildpack.
+- A [`manifest.yml`](https://github.com/cyberark/cloudfoundry-conjur-buildpack/tree/master/manifest.yml)
+  has been added, allowing for the usage of
+  [buildpack-packager](https://github.com/cloudfoundry/buildpack-packager)
+  and other native CloudFoundry features. Please refer to
+  [`manifest.yml`](https://github.com/cyberark/cloudfoundry-conjur-buildpack/tree/master/manifest.yml)
+  for information on dependencies and deprecation notices thereof, as well as
+  a list of files included in the Buildpack.
   [cyberark/cloudfoundry-conjur-buildpack#79](https://github.com/cyberark/cloudfoundry-conjur-buildpack/issues/79)
 
 ### Changed


### PR DESCRIPTION
### What does this PR do?
Updates link in changelog to be absolute instead of relative, so that downstream release notes aggregation has valid links.

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation