### PR TITLE
Update copy-release-to-latest-branch.yml

### DIFF
--- a/.github/workflows/copy-release-to-latest-branch.yml
+++ b/.github/workflows/copy-release-to-latest-branch.yml
@@ -45,7 +45,7 @@ jobs:
         git push --force "https://${{ github.actor }}:${{secrets.GITHUB_TOKEN}}@github.com/${{ github.repository }}.git" "HEAD:refs/heads/${{ steps.data.outputs.UPDATE_BRANCH }}"
 
     - name: Open a PR to archive the tag in the latest branch
-      uses: vsoch/pull-request-action@d987bc1 # Pinned v1.0.2
+      uses: vsoch/pull-request-action@d987bc1511ae006bb9e97cf7765d1a2dbd350aac # Pinned v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PULL_REQUEST_FROM_BRANCH: "${{ steps.data.outputs.UPDATE_BRANCH }}"

--- a/.github/workflows/copy-release-to-latest-branch.yml
+++ b/.github/workflows/copy-release-to-latest-branch.yml
@@ -45,7 +45,7 @@ jobs:
         git push --force "https://${{ github.actor }}:${{secrets.GITHUB_TOKEN}}@github.com/${{ github.repository }}.git" "HEAD:refs/heads/${{ steps.data.outputs.UPDATE_BRANCH }}"
 
     - name: Open a PR to archive the tag in the latest branch
-      uses: vsoch/pull-request-action@d987bc1511ae006bb9e97cf7765d1a2dbd350aac # Pinned v1.0.2
+      uses: vsoch/pull-request-action@1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PULL_REQUEST_FROM_BRANCH: "${{ steps.data.outputs.UPDATE_BRANCH }}"


### PR DESCRIPTION
### What does this PR do?
Updates the gh action to use the full commit hash.

Currently the action fails with the error:
```
 Unable to resolve action `vsoch/pull-request-action@d987bc1`, the provided ref `d987bc1` is the shortened version of a commit SHA, which is not supported. Please use the full commit SHA `d987bc1511ae006bb9e97cf7765d1a2dbd350aac` instead. 
```

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation