### PR TITLE
Fixes scrambled error output when call to retrieve script is nested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed scrambled error messages (e.g. with invalid line numbers) that were
+  generated whenever the Cloudfoundry Buildpack encountered errors while
+  parsing environment variable settings after retrieving secrets variables
+  from Conjur.
+  [cyberark/cloudfoundry-conjur-buildpack#120](https://github.com/cyberark/cloudfoundry-conjur-buildpack/issues/120)
+
 ## [2.2.0] - 2020-03-01
 ### Added
 - Support for using Summon environments in the `secrets.yml` file. Users can now

--- a/lib/0001_retrieve-secrets.sh
+++ b/lib/0001_retrieve-secrets.sh
@@ -12,7 +12,7 @@ echo "[cyberark-conjur-buildpack]: retrieving & injecting secrets"
 err_report() {
     local previous_exit=$?
     trap - ERR
-    printf "%s: Error on line %s" "${BASH_SOURCE[@]}" "$1" 1>&2
+    printf "%s: Error on line %s" "${BASH_SOURCE[0]}" "$1" 1>&2
     exit ${previous_exit}
 }
 trap 'err_report $LINENO' ERR
@@ -26,7 +26,7 @@ trap 'rm -f "$temp_err_file"' EXIT
 conjur_env_err() {
     local previous_exit=$?
     trap - ERR
-    printf "%s: Error on line %s: $(<"$temp_err_file")" "${BASH_SOURCE[@]}" "$1"
+    printf "%s: Error on line %s: $(<"$temp_err_file")" "${BASH_SOURCE[0]}" "$1"
     exit ${previous_exit}
 }
 
@@ -36,7 +36,7 @@ conjur_env_err() {
 export_err() {
     local previous_exit=$?
     trap - ERR
-    printf "%s: Error on line %s: Unable to export \`%s\`; value may not be a valid identifier" "${BASH_SOURCE[@]}" "$1" "$2"
+    printf "%s: Error on line %s: Unable to export \`%s\`; value may not be a valid identifier" "${BASH_SOURCE[0]}" "$1" "$2"
     exit ${previous_exit}
 }
 

--- a/tests/retrieve-secrets/stop
+++ b/tests/retrieve-secrets/stop
@@ -3,6 +3,7 @@
 function finish {
   echo 'Removing environment...'
 
+  rm -rf temp_clone_dir
   docker-compose down -v
 }
 

--- a/tests/retrieve-secrets/test
+++ b/tests/retrieve-secrets/test
@@ -97,6 +97,9 @@ source_test_file() {
   assert_failure
   assert_output -p '`BAD.VAR`; value may not be a valid identifier'
 
+  # Output should not contain an invalid line number
+  refute_output --regexp 'Error on line .*[^0-9].*: Unable to export'
+
   # We should exit after the first error, so these variables shouldn't be present
   refute_output -p '2BADVAR'
   refute_output -p '1234'


### PR DESCRIPTION
### What does this PR do?

This change fixes an issue whereby:
- If the `0001_retrieve-secrets.sh` script is being sourced/called from another script (as is done in production)
- And an error occurs in parsing the variable settings in the `conjur-env` binary output (e.g. for an invalid variable name)
- Then the fields of error messages being generated by the `0001_retrieve-secrets.sh` script were getting scrambled and the error message was getting concatenated multiple times.

Here is an example of an error that was getting generated:

```
./tmp/0001_retrieve-secrets.sh: Error on line ./tmp/0001_retrieve-secrets.sh: Unable to export `/tmp/bats-run-1/bats.111.src`; value may not be a valid identifier/opt/bats/lib/bats-core/test_functions.bash: Error on line /tmp/bats-run-1/bats.111.src: Unable to export `/opt/bats/libexec/bats-core/bats-exec-test`; value may not be a valid identifier/opt/bats/libexec/bats-core/bats-exec-test: Error on line 74: Unable to export `ANOTHER_BAD.VAR`; value may not be a valid identifier
```

The source of the problem is that the error message printf format was using
an expanded Bash array (`BASH_SOURCE[@]`) (rather than the first
element) to display the script name, and the elements of the array were
then being used for subsequent printf fields.

### What ticket does this PR close?
Resolves #120

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation