### PR TITLE
Use VMWare ISV Service for CI clusters

### DIFF
--- a/Dockerfile.packager
+++ b/Dockerfile.packager
@@ -1,5 +1,3 @@
 FROM golang:latest
 
-RUN go get github.com/cloudfoundry/libbuildpack/packager/buildpack-packager
-
 RUN go install github.com/cloudfoundry/libbuildpack/packager/buildpack-packager@latest

--- a/ci/get_compute_ip
+++ b/ci/get_compute_ip
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Get the IP of the compute instance in an ISV TAS cluster.
+# This is so the IP can be added to IPManager to allow the service broker to connect to
+# the CI Conjur instance.
+# This is a seperate script to make it easier to run within the tanzuclis docker image.
+
+deployment="$(hammer -t "${HAMMERFILE}" bosh -- deployments --json |jq -r .Tables[0].Rows[0].name)"
+hammer -t "${HAMMERFILE}" bosh -- --deployment "${deployment}" ssh compute --command 'curl\ checkip.amazonaws.com' |grep stdout |cut -d' ' -f 4| tr -dc '0-9.'

--- a/ci/secrets.yml
+++ b/ci/secrets.yml
@@ -1,2 +1,4 @@
 CF_API_ENDPOINT: !var ci/pcf/api-url
 CF_ADMIN_PASSWORD: !var ci/pcf/admin-cli-password
+
+IPMANAGER_TOKEN: !var prod/ipmanager/request-secret

--- a/ci/test_conjur-env
+++ b/ci/test_conjur-env
@@ -7,16 +7,17 @@ docker run \
   -v "$(pwd)/conjur-env:/cyberark" \
   -w /cyberark \
   --rm golang \
-  sh -c '''
+  bash -c '''
+  set -euo pipefail
   # Run golint
-  go get -u golang.org/x/lint/golint
+  go install golang.org/x/lint/golint@latest
   golint -set_exit_status ./...
 
   # Run go vet
   go vet ./...
 
   # Run unit test with coverage
-  go get -u github.com/jstemmer/go-junit-report
+  go install github.com/jstemmer/go-junit-report@latest
   mkdir -p output
   go test -coverprofile=output/c.out -v . | tee /dev/stderr | go-junit-report > output/junit.xml
   '''

--- a/ci/test_e2e
+++ b/ci/test_e2e
@@ -1,6 +1,5 @@
 #!/bin/bash -e
 
-#
 # Remote Integration Test Runner
 #
 # This runs only e2e features, which are those dependent on
@@ -9,13 +8,32 @@
 # proper summon credentials.
 #
 
-# First, check for summon variables
-: "${CF_API_ENDPOINT?"Error: Need to set CF_API_ENDPOINT"}"
-
 cd "$(dirname "$0")"
 # shellcheck disable=SC1091
 . ./utils
-trap finish EXIT
+
+function cleanup(){
+  if [[ -z "${compute_ip:-}" ]]; then
+    ipmanager remove "${compute_ip}" || true
+  fi
+  finish
+}
+trap cleanup EXIT
+
+# Allow hammerfile path to be overidden, but default to hammerfile.json
+# in the root of the repo.
+HAMMERFILE_DEFAULT="$(git rev-parse --show-toplevel)/hammerfile.json"
+export HAMMERFILE="${HAMMERFILE:-"${HAMMERFILE_DEFAULT}"}"
+
+if [[ -r "${HAMMERFILE}" ]]; then
+  getISVCFCreds
+  addComputeIPToIPManager || { sleep 30; addComputeIPToIPManager; }
+else
+  echo "Hammerfile not detected"
+fi
+
+# First, check for summon variables
+: "${CF_API_ENDPOINT?"Error: Need to set CF_API_ENDPOINT"}"
 
 setup_env
 build_test_images

--- a/ci/test_unit
+++ b/ci/test_unit
@@ -1,12 +1,11 @@
 #!/bin/bash -e
 
-cd "$(dirname "$0")"
 # shellcheck disable=SC1091
-. ./utils
+. ci/utils
 
 announce 'Running Golint and Vet against the Conjur-Env...'
 # Unit Test Runner
-./test_conjur-env
+./ci/test_conjur-env
 
 announce 'Running unit tests for the secrets retrieval script...'
-../tests/retrieve-secrets/start
+tests/retrieve-secrets/start

--- a/ci/utils
+++ b/ci/utils
@@ -45,3 +45,59 @@ function start_conjur {
 
   docker-compose -f "$DOCKER_COMPOSE_FILE" exec -T conjur conjurctl wait -r 45 -p 80
 }
+
+
+function addComputeIPToIPManager(){
+  announce "Adding TAS Compute IP to IPManager"
+  pushd "$(git rev-parse --show-toplevel)" >/dev/null
+    compute_ip="$(docker run \
+      --rm \
+      -e HAMMERFILE \
+      --volume "${PWD}:${PWD}" \
+      --workdir "${PWD}" \
+      registry.tld/tanzuclis \
+        ./ci/get_compute_ip)"
+    ipmanager add "${compute_ip}"
+  popd > /dev/null
+  echo "Done"
+}
+
+# Add or remove IP from IPManager's allow list
+function ipmanager(){
+  verb="${1:-add}"
+  ip="${2}"
+  echo "IPmanager: ${verb} ${ip}"
+  curl \
+  --silent \
+  --show-error \
+  --fail \
+  -X POST  \
+  -H "Content-Type: application/json" \
+  -d "{\"sharedsecret\":\"${IPMANAGER_TOKEN}\", \"ip\":\"${ip}\", \"expiry_hours\": \"2\"}" \
+  https://ipmanager.itp.conjur.net/${verb}ip
+}
+
+function getISVCFCreds(){
+  announce "Configuring ISV TAS cluster via hammerfile"
+  # The hammerfile is written to the root of the repo
+  # So need to run from the root so its accessible
+  # within the container.
+  pushd "$(git rev-parse --show-toplevel)" >/dev/null
+    CF_ADMIN_PASSWORD="$(docker run \
+      --rm \
+      -e HAMMERFILE \
+      --volume "${PWD}:${PWD}" \
+      --workdir "${PWD}" \
+      registry.tld/tanzuclis \
+        bash -c 'source $(hammer -t "${HAMMERFILE}" cf-login --file |tail -n1)>/dev/null; echo $CF_PASSWORD')"
+    # cf-login --file writes a script to a file and outputs its path.
+    # The script exports CF_PASSWORD, so we source the script then echo CF_PASSWORD and capture
+    # it in CF_ADMIN_PASSWORD
+  popd >/dev/null
+
+  CF_API_ENDPOINT="https://api.$(jq -r .sys_domain "${HAMMERFILE}")"
+
+  export CF_ADMIN_PASSWORD
+  export CF_API_ENDPOINT
+  echo "Done"
+}

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       BUILDPACK_BUILD_DIR: /cyberark/cloudfoundry-conjur-buildpack/conjur_buildpack #tests run against the code in this directory
       CF_STACK: cflinuxfs3
-      CF_API_ENDPOINT: 
+      CF_API_ENDPOINT:
       CF_ADMIN_PASSWORD:
       BRANCH_NAME:
     volumes:

--- a/tests/integration/apps/java/bin/build
+++ b/tests/integration/apps/java/bin/build
@@ -7,4 +7,4 @@ docker run \
   -v $(pwd):/app \
   -w /app \
   maven:3.5.2-jdk-8 \
-  mvn package
+  mvn --batch-mode package


### PR DESCRIPTION
Previously infra provided TAS clusters in AWS. This commit switches
to using clusters provided by VMWare. These clusters are single use,
allocated and deallocated during the pipeline.

Related: conjurinc/ops#857