### PR TITLE
Update sinatra to 2.2.0 for CVE-2022-29970

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.2.3] - 2022-05-10
+
+### Security
+- Updated sinatra in ruby test app to 2.2.0
+  [cyberark/cloudfoundry-conjur-buildpack#135](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/135)
+
 ## [2.2.2] - 2022-01-03
 ### Changed
 - Updated conjur-api-go to version 0.8.1

--- a/tests/integration/apps/ruby/Gemfile
+++ b/tests/integration/apps/ruby/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 ruby '~> 2.5'
 
-gem 'sinatra', ">= 2.0.2"
+gem 'sinatra', ">= 2.2.0"
 gem 'rack', ">= 2.0.6"
 
 gem 'conjur-api'

--- a/tests/integration/apps/ruby/Gemfile.lock
+++ b/tests/integration/apps/ruby/Gemfile.lock
@@ -33,23 +33,25 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     minitest (5.14.1)
-    mustermann (1.0.3)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
     netrc (0.11.0)
-    rack (2.1.4)
-    rack-protection (2.0.5)
+    rack (2.2.3)
+    rack-protection (2.2.0)
       rack
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    sinatra (2.0.5)
+    ruby2_keywords (0.0.5)
+    sinatra (2.2.0)
       mustermann (~> 1.0)
-      rack (~> 2.0)
-      rack-protection (= 2.0.5)
+      rack (~> 2.2)
+      rack-protection (= 2.2.0)
       tilt (~> 2.0)
     table_print (1.5.6)
     thread_safe (0.3.6)
-    tilt (2.0.9)
+    tilt (2.0.10)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unf (0.1.4)
@@ -65,7 +67,10 @@ DEPENDENCIES
   conjur-api
   conjur-cli
   rack (>= 2.0.6)
-  sinatra (>= 2.0.2)
+  sinatra (>= 2.2.0)
+
+RUBY VERSION
+   ruby 2.6.3p62
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### Desired Outcome

Clear Dependabot alert on sinatra

### Implemented Changes

Upgrades sinatra to 2.2.0

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [X] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [X] No behavior was changed with this PR

#### Security

- [X] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
