### PR TITLE
Upgrade project Golang version to 1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.2.3] - 2022-05-10
 
+### Changed
+- Project Go version bumped to 1.17, and support for deprecated Go versions
+  1.14.x and 1.15.x removed.
+  [cyberark/cloudfoundry-conjur-buildpack#137](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/137)
+
 ### Security
 - Updated sinatra in ruby test app to 2.2.0
   [cyberark/cloudfoundry-conjur-buildpack#135](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/135)
+- Golang-based Docker images bumped to version `1.17.9-stretch`
+  [cyberark/cloudfoundry-conjur-buildpack#137](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/137)
 
 ## [2.2.2] - 2022-01-03
 ### Changed

--- a/ci/start_dev_environment
+++ b/ci/start_dev_environment
@@ -9,7 +9,8 @@ build_test_images
 start_conjur
 
 # Runs the cflinux3 image in interactive mode with the project files mounted
-docker-compose run --rm \
+docker-compose \
   -f "$DOCKER_COMPOSE_FILE" \
+  run --rm \
   -e BUILDPACK_BUILD_DIR="/cyberark/cloudfoundry-conjur-buildpack/conjur_buildpack" \
   tester bash

--- a/conjur-env/Dockerfile
+++ b/conjur-env/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-stretch
+FROM golang:1.17.9-stretch
 MAINTAINER CyberArk Software, Inc.
 
 ENV GOOS=linux \

--- a/lib/install_go.sh
+++ b/lib/install_go.sh
@@ -5,10 +5,10 @@
 
 set -euo pipefail
 
-GO_VERSION="1.14"
+GO_VERSION="1.17.9"
 
 if [ "${CF_STACK}" == "cflinuxfs3" ]; then
-    GO_SHA256="7791b658b10dba530754c9dbdf52dcdec03b77c250ee44701a6120580feb5038"
+    GO_SHA256="a620909b3dc54e17a7769dbcb95bc9fbac60dd376c730b09afaee984d4d7da91"
 else
   echo "       **ERROR** Unsupported stack"
   echo "                 See https://docs.cloudfoundry.org/devguide/deploy-apps/stacks.html for more info"
@@ -19,7 +19,7 @@ export GoInstallDir="/tmp/go${GO_VERSION}"
 mkdir -p "${GoInstallDir}"
 
 if [ ! -f "${GoInstallDir}/go/bin/go" ]; then
-  URL="https://buildpacks.cloudfoundry.org/dependencies/go/go${GO_VERSION}.linux-amd64-${CF_STACK}-${GO_SHA256:0:8}.tgz"
+  URL="https://buildpacks.cloudfoundry.org/dependencies/go/go_${GO_VERSION}_linux_x64_${CF_STACK}_${GO_SHA256:0:8}.tgz"
 
   echo "-----> Download go ${GO_VERSION}"
   curl -s -L --retry 15 --retry-delay 2 "${URL}" -o /tmp/go.tar.gz

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,49 +4,29 @@ metadata:
     contact: "Conjur Maintainers - conj_maintainers@cyberark.com"
 default_versions:
   - name: go
-    version: 1.15.x
+    version: 1.17.x
 dependency_deprecation_dates:
-  - version_line: 1.14.x
+  - version_line: 1.17.x
     name: go
-    date: 2021-02-25
-    link: https://golang.org/doc/devel/release.html
-  - version_line: 1.15.x
-    name: go
-    date: 2021-08-11
+    date: 2022-09-15
     link: https://golang.org/doc/devel/release.html
 dependencies:
 - name: go
-  version: 1.14.11
-  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.14.11_linux_x64_cflinuxfs3_48d06585.tgz
-  sha256: 48d06585c8fe0694377b9772aac0e17e202817e8dc79336207ff890e5b794387
+  version: 1.17.8
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.17.8_linux_x64_cflinuxfs3_57a37267.tgz
+  sha256: 57a37267066d80ba182f8b4e4d715d1a0e3a775e26c3be608eda0ed572a231ca
   cf_stacks:
     - cflinuxfs3
-  source: https://dl.google.com/go/go1.14.11.src.tar.gz
-  source_sha256: 1871f3d29b0cf1ebb739c9b134c9bc559282bd3625856e5f12f5aea29ab70f16
+  source: https://dl.google.com/go/go1.17.8.src.tar.gz
+  source_sha256: 2effcd898140da79a061f3784ca4f8d8b13d811fb2abe9dad2404442dabbdf7a
 - name: go
-  version: 1.14.12
-  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.14.12_linux_x64_cflinuxfs3_df335fd0.tgz
-  sha256: df335fd03d21cf1ea4d89e691bef1c012b542fc7d7d293dcbf957cabaeeab4e0
+  version: 1.17.9
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.17.9_linux_x64_cflinuxfs3_a620909b.tgz
+  sha256: a620909b3dc54e17a7769dbcb95bc9fbac60dd376c730b09afaee984d4d7da91
   cf_stacks:
     - cflinuxfs3
-  source: https://dl.google.com/go/go1.14.12.src.tar.gz
-  source_sha256: b34f4b7ad799eab4c1a52bdef253602ce957125a512f5a1b28dce43c6841b971
-- name: go
-  version: 1.15.4
-  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.15.4_linux_x64_cflinuxfs3_3236396b.tgz
-  sha256: 3236396b95396f1cd00cea369fb7fdf6245c04904f4147ea4eaaf86b1445285b
-  cf_stacks:
-    - cflinuxfs3
-  source: https://dl.google.com/go/go1.15.4.src.tar.gz
-  source_sha256: 063da6a9a4186b8118a0e584532c8c94e65582e2cd951ed078bfd595d27d2367
-- name: go
-  version: 1.15.5
-  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.15.5_linux_x64_cflinuxfs3_fd04494f.tgz
-  sha256: fd04494f7a2dd478b0d31cb949aae7f154749cae1242581b1574f7e590b3b7e6
-  cf_stacks:
-    - cflinuxfs3
-  source: https://dl.google.com/go/go1.15.5.src.tar.gz
-  source_sha256: c1076b90cf94b73ebed62a81d802cd84d43d02dea8c07abdc922c57a071c84f1
+  source: https://dl.google.com/go/go1.17.9.src.tar.gz
+  source_sha256: 763ad4bafb80a9204458c5fa2b8e7327fa971aee454252c0e362c11236156813
 include_files:
 - CHANGELOG.md
 - CONTRIBUTING.md

--- a/tests/retrieve-secrets/Dockerfile
+++ b/tests/retrieve-secrets/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.6-stretch
+FROM golang:1.17.9-stretch
 MAINTAINER CyberArk Software, Inc.
 
 ENV GOOS=linux \

--- a/tests/retrieve-secrets/go.mod
+++ b/tests/retrieve-secrets/go.mod
@@ -1,3 +1,3 @@
 module github.com/cyberark/cloudfoundry-conjur-buildpack/ci/mock-conjur-env
 
-go 1.14
+go 1.17


### PR DESCRIPTION
### Desired Outcome

Upgrade Golang Dockerfile base images to fix OpenSSL CVE-2022-0778 and CVE-2022-1292.

### Implemented Changes

- Upgrade Dockerfile base images to `golang:1.17.9-stretch`, which uses OpenSSL v1.1.0l
- Upgrade project Go version to 1.17
- Remove deprecated Go 1.14 and 1.15 dependencies

### Connected Issue/Story

CyberArk internal issue link: [CONJSE-1310](https://ca-il-jira.il.cyber-ark.com:8443/browse/CONJSE-1310)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
