### PR TITLE
Pin CI TAS Environment to 2.13

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ pipeline {
 
         stage('End To End Tests') {
           steps {
-            allocateTas()
+            allocateTas('isv_ci_tas_srt_2_13')
             sh 'summon -f ./ci/secrets.yml ./ci/test_e2e'
             junit 'tests/integration/reports/e2e/*.xml'
           }


### PR DESCRIPTION
TAS 3.0 was recently released which broke deployment scripts, so the latest 2.x will be used until 3.0 compatibility is complete.

Related: ONYX-26801