### PR TITLE
Update java test app to Spring Boot 2.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated conjur-env dependencies to latest versions (github.com/cyberark/summon -> v0.9.4,
   github.com/stretchr/testify -> v1.8.0) [cyberark/cloudfoundry-conjur-buildpack#149](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/149)
 
+### Security
+- Updated tests/integration/apps/java to use Spring Framework 2.7.5
+  [cyberark/cloudfoundry-conjur-buildpack#155](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/155)
+
 ## [2.2.4] - 2022-06-16
 ### Changed
 - Updated conjur-api-go to 0.10.1 and summon to 0.9.3 in conjur-env/go.mod

--- a/tests/integration/apps/java/pom.xml
+++ b/tests/integration/apps/java/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.0</version>
+    <version>2.7.5</version>
   </parent>
 
   <dependencies>


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

Upgrade Spring Boot Starter Web to 2.7.5 to resolve some vulnerable indirect dependencies
