### PR TITLE
Update summon to v0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   github.com/stretchr/testify -> v1.8.0) [cyberark/cloudfoundry-conjur-buildpack#149](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/149)
 
 ### Security
+- Updated Summon, golang.org/x/net, and golang.org/x/text dependencies
+  [cyberark/cloudfoundry-conjur-buildpack#156](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/156)
 - Updated tests/integration/apps/java to use Spring Framework 2.7.5
   [cyberark/cloudfoundry-conjur-buildpack#155](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/155)
 

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -17,12 +17,12 @@ SECTION 1: Apache License 2.0
 SECTION 2: BSD 3-clause "New" or "Revised" License
 
 >>> github.com/pmezard/go-difflib-1.0.0
->>> golang.org/x/sys-0.0.0-20211216021012-1d35b9e2eb4e
+>>> golang.org/x/sys-0.0.0-20220728004956-3c1f35247d10
 
 SECTION 3: MIT License
 
 >>> github.com/bgentry/go-netrc-0.0.0-20140422174119-9fd32a8b3d3d
->>> github.com/cyberark/summon-0.9.4
+>>> github.com/cyberark/summon-0.9.5
 >>> github.com/sirupsen/logrus-1.8.1
 >>> github.com/stretchr/testify v1.8.0
 >>> gopkg.in/yaml.v2-2.4.0
@@ -110,7 +110,7 @@ limitations under the License.
 
 BSD 3-clause "New" or "Revised" License is applicable to the following component(s).
 
->>> golang.org/x/sys-0.0.0-20211216021012-1d35b9e2eb4e
+>>> golang.org/x/sys-0.0.0-20220728004956-3c1f35247d10
 
 Copyright (c) 2009 The Go Authors. All rights reserved.
 
@@ -198,7 +198,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
->>> github.com/cyberark/summon-0.9.4
+>>> github.com/cyberark/summon-0.9.5
 
 The MIT License (MIT)
 

--- a/conjur-env/go.mod
+++ b/conjur-env/go.mod
@@ -2,7 +2,7 @@ module github.com/cyberark/cloudfoundry-conjur-buildpack/conjur-env
 
 require (
 	github.com/cyberark/conjur-api-go v0.10.1
-	github.com/cyberark/summon v0.9.4
+	github.com/cyberark/summon v0.9.5
 	github.com/stretchr/testify v1.8.0
 )
 
@@ -13,7 +13,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
-	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/conjur-env/go.sum
+++ b/conjur-env/go.sum
@@ -3,8 +3,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyberark/conjur-api-go v0.10.1 h1:3gaKBINNyz9KGaY8SWatODVziINHYVmz+uAXKYujwIA=
 github.com/cyberark/conjur-api-go v0.10.1/go.mod h1:8+qYC7L6wPY1e56hoZmHSdGa2fHALck8PtS+cUky75Y=
-github.com/cyberark/summon v0.9.4 h1:vg6gpc8e+l7ILh2bGYDqWpGtamjgLgKLHXAj8d6Shy8=
-github.com/cyberark/summon v0.9.4/go.mod h1:o6y8/NyiqA2+cneZKkGt9NsfhQK2wD0+aWDgPqLWiGk=
+github.com/cyberark/summon v0.9.5 h1:xV/bbI4G9wBOAhtcLCZEFF9ER/3AaTKSPRQyeumpwiI=
+github.com/cyberark/summon v0.9.5/go.mod h1:kT7+4i+d5xvv6HyBQfc2bAexaaZEyOF0XsmNlA/0jWQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -28,8 +28,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 h1:WIoqL4EROvwiPdUtaip4VcDdpZ4kha7wBWZrbVKCIZg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=

--- a/tests/integration/apps/ruby/Gemfile
+++ b/tests/integration/apps/ruby/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby '~> 2.5'
 
 gem 'sinatra', ">= 2.2.0"
-gem 'rack', ">= 2.0.6"
+gem 'rack', ">= 2.2.4"
 
 gem 'conjur-api'
 gem 'conjur-cli'

--- a/tests/integration/apps/ruby/Gemfile.lock
+++ b/tests/integration/apps/ruby/Gemfile.lock
@@ -35,7 +35,7 @@ GEM
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
     netrc (0.11.0)
-    rack (2.2.3.1)
+    rack (2.2.4)
     rack-protection (2.2.0)
       rack
     rest-client (2.0.2)
@@ -63,7 +63,7 @@ PLATFORMS
 DEPENDENCIES
   conjur-api
   conjur-cli
-  rack (>= 2.0.6)
+  rack (>= 2.2.4)
   sinatra (>= 2.2.0)
 
 RUBY VERSION


### PR DESCRIPTION
### Desired Outcome

Update Summon to v0.9.5 to address golang.org/x/net and golang.org/x/text vulnerabilities.

### Implemented Changes

Update Summon in go.mod.

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
