### PR TITLE
Pin Bundler at v2.3.26

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -21,7 +21,7 @@ RUN wget -q https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key &&
 
 # Install ruby dependencies
 RUN mkdir -p "$TEST_PATH" && \
-    gem install bundler && \
+    gem install bundler -v 2.3.26 && \
     # This will prevent warnings about installing gems as root
     bundle config --global silence_root_warning 1
 


### PR DESCRIPTION
### Desired Outcome

Fix the project's Jenkins build. Related logs:
```
Step 6/8 : RUN mkdir -p "$TEST_PATH" &&     gem install bundler &&     bundle config --global silence_root_warning 1
 ---> Running in c0d621a3d929
ERROR:  Error installing bundler:
	The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.3.26. Try installing it with `gem install bundler -v 2.3.26`
	bundler requires Ruby version >= 2.6.0. The current ruby version is 2.5.0.
```

### Implemented Changes

The Jenkins build uses a `cloudfoundry/cflinuxfs3` container to test the buildpack, where Ruby 2.5 is the highest version available. I've pinned Bundler to a compatible version.

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
