### PR TITLE
Use Brightbox Ruby package in test Dockerfile

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -10,7 +10,12 @@ RUN apt-get update && \
     apt-get install -y apt-transport-https \
                        ca-certificates \
                        openssl \
-                       ruby2.5-dev
+                       software-properties-common
+
+# Install Ruby 2.5
+RUN apt-add-repository ppa:brightbox/ruby-ng && \
+    apt-get update && \
+    apt-get install -y ruby2.5-dev
 
 # Install the Cloud Foundry CLI
 RUN wget -q https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key && \


### PR DESCRIPTION
### Desired Outcome

Fix Jenkins build. Logs:

```
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:
The following packages have unmet dependencies:
 ruby2.5-dev : Depends: libruby2.5 (= 2.5.1-1ubuntu1.16) but 2.5.1-1ubuntu1.16+esm1 is to be installed
               Recommends: ruby2.5-doc but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

### Implemented Changes

Use Brightbox's Ruby 2.5 packages instead defaults.

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
