### PR TITLE
Add support for TAS 3.0, 4.0 and 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Support for TAS 4.0 and 5.0, and associated `cflinuxfs4` stack.
+  [cyberark/cloudfoundry-conjur-buildpack#178](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/178)
+
+### Changed
+- Project Go version bumped to 1.20, and support for deprecated Go version 1.17 removed.
+  [cyberark/cloudfoundry-conjur-buildpack#178](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/178)
+
 ## [2.2.8] - 2023-06-21
 ### Security
 - Upgrade golang.org/x/net to v0.10.0, golang.org/x/text to v0.9.0, golang.org/x/sys to v0.8.0, rack to 3.0.1,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ pipeline {
 
         stage('End To End Tests') {
           steps {
-            allocateTas('isv_ci_tas_srt_2_13')
+            allocateTas('isv_ci_tas_srt_5_0')
             sh 'summon -f ./ci/secrets.yml ./ci/test_e2e'
             junit 'tests/integration/reports/e2e/*.xml'
           }

--- a/ci/start_dev_environment
+++ b/ci/start_dev_environment
@@ -8,7 +8,7 @@ trap finish EXIT
 build_test_images
 start_conjur
 
-# Runs the cflinux3 image in interactive mode with the project files mounted
+# Runs the cflinux4 image in interactive mode with the project files mounted
 docker-compose \
   -f "$DOCKER_COMPOSE_FILE" \
   run --rm \

--- a/lib/install_go.sh
+++ b/lib/install_go.sh
@@ -5,10 +5,12 @@
 
 set -euo pipefail
 
-GO_VERSION="1.17.9"
+GO_VERSION="1.20.9"
 
 if [ "${CF_STACK}" == "cflinuxfs3" ]; then
-    GO_SHA256="a620909b3dc54e17a7769dbcb95bc9fbac60dd376c730b09afaee984d4d7da91"
+    GO_SHA256="2bf83781fa63a1edc157368f2564c20b50a0fcabfaf95b80ad373f15c3555a6a"
+elif [ "${CF_STACK}" == "cflinuxfs4" ]; then
+    GO_SHA256="23cc8463b6bbe90f08dbf28e2a501886ccf1c01d45e6ebd58b59ec0e5973198d"
 else
   echo "       **ERROR** Unsupported stack"
   echo "                 See https://docs.cloudfoundry.org/devguide/deploy-apps/stacks.html for more info"

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,30 +3,50 @@ metadata:
   annotations:
     contact: "Conjur Maintainers - conj_maintainers@cyberark.com"
 default_versions:
-  - name: go
-    version: 1.17.x
+- name: go
+  version: 1.20.x
 dependency_deprecation_dates:
-  - version_line: 1.17.x
-    name: go
-    date: 2022-09-15
-    link: https://golang.org/doc/devel/release.html
+- version_line: 1.20.x
+  name: go
+  date: 2024-02-01
+  link: https://golang.org/doc/devel/release.html
+- version_line: 1.21.x
+  name: go
+  date: 2024-08-15
+  link: https://golang.org/doc/devel/release.html
 dependencies:
 - name: go
-  version: 1.17.8
-  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.17.8_linux_x64_cflinuxfs3_57a37267.tgz
-  sha256: 57a37267066d80ba182f8b4e4d715d1a0e3a775e26c3be608eda0ed572a231ca
+  version: 1.20.9
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.20.9_linux_x64_cflinuxfs3_2bf83781.tgz
+  sha256: 2bf83781fa63a1edc157368f2564c20b50a0fcabfaf95b80ad373f15c3555a6a
   cf_stacks:
-    - cflinuxfs3
-  source: https://dl.google.com/go/go1.17.8.src.tar.gz
-  source_sha256: 2effcd898140da79a061f3784ca4f8d8b13d811fb2abe9dad2404442dabbdf7a
+  - cflinuxfs3
+  source: https://dl.google.com/go/go1.20.9.src.tar.gz
+  source_sha256: 4923920381cd71d68b527761afefa523ea18c5831b4795034c827e18b685cdcf
 - name: go
-  version: 1.17.9
-  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.17.9_linux_x64_cflinuxfs3_a620909b.tgz
-  sha256: a620909b3dc54e17a7769dbcb95bc9fbac60dd376c730b09afaee984d4d7da91
+  version: 1.20.9
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.20.9_linux_x64_cflinuxfs4_23cc8463.tgz
+  sha256: 23cc8463b6bbe90f08dbf28e2a501886ccf1c01d45e6ebd58b59ec0e5973198d
   cf_stacks:
-    - cflinuxfs3
-  source: https://dl.google.com/go/go1.17.9.src.tar.gz
-  source_sha256: 763ad4bafb80a9204458c5fa2b8e7327fa971aee454252c0e362c11236156813
+  - cflinuxfs4
+  source: https://dl.google.com/go/go1.20.9.src.tar.gz
+  source_sha256: 4923920381cd71d68b527761afefa523ea18c5831b4795034c827e18b685cdcf
+- name: go
+  version: 1.21.2
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.21.2_linux_x64_cflinuxfs3_9d661bee.tgz
+  sha256: 9d661beeb4de39f9beacbca1564f31ca5ca0a7f8b365aa5c2cfcfcf5a11ebad0
+  cf_stacks:
+  - cflinuxfs3
+  source: https://dl.google.com/go/go1.21.2.src.tar.gz
+  source_sha256: 45e59de173baec39481854490d665b726cec3e5b159f6b4172e5ec7780b2c201
+- name: go
+  version: 1.21.2
+  uri: https://buildpacks.cloudfoundry.org/dependencies/go/go_1.21.2_linux_x64_cflinuxfs4_b900d2c1.tgz
+  sha256: b900d2c13f6b229ab9c0d338582824e6b76f74359aa9c5a7e2169029b3cb2612
+  cf_stacks:
+  - cflinuxfs4
+  source: https://dl.google.com/go/go1.21.2.src.tar.gz
+  source_sha256: 45e59de173baec39481854490d665b726cec3e5b159f6b4172e5ec7780b2c201
 include_files:
 - CHANGELOG.md
 - CONTRIBUTING.md

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM cloudfoundry/cflinuxfs3
+FROM cloudfoundry/cflinuxfs4
 
 ENV WD_PATH="/cyberark/cloudfoundry-conjur-buildpack" \
     TEST_PATH="/cyberark/cloudfoundry-conjur-buildpack/tests"
@@ -10,12 +10,7 @@ RUN apt-get update && \
     apt-get install -y apt-transport-https \
                        ca-certificates \
                        openssl \
-                       software-properties-common
-
-# Install Ruby 2.5
-RUN apt-add-repository ppa:brightbox/ruby-ng && \
-    apt-get update && \
-    apt-get install -y ruby2.5-dev
+                       ruby-dev
 
 # Install the Cloud Foundry CLI
 RUN wget -q https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key && \

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: buildpack-tester
     environment:
       BUILDPACK_BUILD_DIR: /cyberark/cloudfoundry-conjur-buildpack/conjur_buildpack #tests run against the code in this directory
-      CF_STACK: cflinuxfs3
+      CF_STACK: cflinuxfs4
       CF_API_ENDPOINT:
       CF_ADMIN_PASSWORD:
       BRANCH_NAME:


### PR DESCRIPTION
### Desired Outcome

Update the buildpack to work with the latest TAS v3, v4 and v5.

### Implemented Changes

- Maintain support for `cflinuxfs3` stack (used by TAS v3)
- Add support for `cflinuxfs4` stack (used by TAS v4 and v5)
- Bump project Go version from 1.17.9 to 1.20.9, with support for 1.21.2

### Connected Issue/Story

CyberArk internal issue ID: CNJR-2670

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
