### PR TITLE
CNJR-2127: Use Docker Compose v2

### DIFF
--- a/ci/start_dev_environment
+++ b/ci/start_dev_environment
@@ -9,7 +9,7 @@ build_test_images
 start_conjur
 
 # Runs the cflinux4 image in interactive mode with the project files mounted
-docker-compose \
+docker compose \
   -f "$DOCKER_COMPOSE_FILE" \
   run --rm \
   -e BUILDPACK_BUILD_DIR="/cyberark/cloudfoundry-conjur-buildpack/conjur_buildpack" \

--- a/ci/test_e2e
+++ b/ci/test_e2e
@@ -49,7 +49,7 @@ popd
 
 announce 'Running Cucumber tests...'
 # Run tests against latest build of buildpack (including integration tests against remote foundation)
-docker-compose \
+docker compose \
     -f "$DOCKER_COMPOSE_FILE" \
     run --rm \
     -w "$CONTAINER_FEATURES_DIR" \

--- a/ci/test_integration
+++ b/ci/test_integration
@@ -23,7 +23,7 @@ start_conjur
 [[ -z $JENKINS_HOME ]] && package_and_unpack_buildpack
 
 announce 'Running Cucumber tests...'
-docker-compose \
+docker compose \
     -f "$DOCKER_COMPOSE_FILE" \
     run --rm \
     -w "$CONTAINER_FEATURES_DIR" \

--- a/ci/utils
+++ b/ci/utils
@@ -13,7 +13,7 @@ function announce {
 
 function finish {
   announce 'Removing environment...'
-  docker-compose -f "$DOCKER_COMPOSE_FILE" down -v
+  docker compose -f "$DOCKER_COMPOSE_FILE" down -v
 }
 
 function package_and_unpack_buildpack {
@@ -36,14 +36,14 @@ function setup_env {
 
 function build_test_images {
   announce 'Building test images...'
-  docker-compose -f "$DOCKER_COMPOSE_FILE" build
+  docker compose -f "$DOCKER_COMPOSE_FILE" build
 }
 
 function start_conjur {
   announce 'Waiting for Conjur to start...'
-  docker-compose -f "$DOCKER_COMPOSE_FILE" up -d conjur
+  docker compose -f "$DOCKER_COMPOSE_FILE" up -d conjur
 
-  docker-compose -f "$DOCKER_COMPOSE_FILE" exec -T conjur conjurctl wait -r 45 -p 80
+  docker compose -f "$DOCKER_COMPOSE_FILE" exec -T conjur conjurctl wait -r 45 -p 80
 }
 
 

--- a/conjur-env/build.sh
+++ b/conjur-env/build.sh
@@ -4,5 +4,5 @@ cd "$(dirname "$0")"
 
 rm -rf ../vendor/conjur-env
 
-docker-compose build
-docker-compose run --rm conjur-env-builder
+docker compose build
+docker compose run --rm conjur-env-builder

--- a/conjur-env/docker-compose.yml
+++ b/conjur-env/docker-compose.yml
@@ -1,7 +1,8 @@
 version: '2.1'
 services:
   conjur-env-builder:
-    build: ""
+    build: 
+      context: .
     volumes:
       - .:/conjur-env
       - ../vendor:/pkg

--- a/conjur-env/docker-compose.yml
+++ b/conjur-env/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.1'
 services:
   conjur-env-builder:
     build: 

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   tester:
     build: .

--- a/tests/integration/apps/ruby/Gemfile
+++ b/tests/integration/apps/ruby/Gemfile
@@ -5,5 +5,5 @@ ruby '~> 3.2'
 
 gem 'conjur-api'
 gem 'conjur-cli'
-gem 'thin'
+gem 'puma'
 gem 'roda'

--- a/tests/integration/apps/ruby/Gemfile.lock
+++ b/tests/integration/apps/ruby/Gemfile.lock
@@ -23,11 +23,9 @@ GEM
       netrc (~> 0.10)
       table_print (~> 1.5)
       xdg (= 2.2.3)
-    daemons (1.4.1)
     deep_merge (1.2.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    eventmachine (1.2.7)
     gli (2.21.0)
     highline (2.1.0)
     http-accept (1.7.0)
@@ -40,7 +38,10 @@ GEM
     mime-types-data (3.2023.0218.1)
     minitest (5.18.0)
     netrc (0.11.0)
+    nio4r (2.7.0)
     public_suffix (5.0.1)
+    puma (6.4.0)
+      nio4r (~> 2.0)
     rack (3.0.1)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
@@ -50,10 +51,6 @@ GEM
     roda (3.68.0)
       rack
     table_print (1.5.7)
-    thin (1.8.2)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0, >= 1.0.4)
-      rack (>= 1, < 3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
@@ -68,8 +65,8 @@ PLATFORMS
 DEPENDENCIES
   conjur-api
   conjur-cli
+  puma
   roda
-  thin
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/tests/integration/apps/ruby/Procfile
+++ b/tests/integration/apps/ruby/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma

--- a/tests/integration/apps/ruby/Procfile
+++ b/tests/integration/apps/ruby/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec puma
+web: bundle exec puma -b tcp://0.0.0.0:8080

--- a/tests/integration/features/integration.feature
+++ b/tests/integration/features/integration.feature
@@ -14,28 +14,10 @@ Feature: Integrations Tests for remote TAS foundation
       Given I create an org and space
       And I install the buildpack
 
-    Scenario: Python offline buildpack integration
-      When I push a "python" app with the "offline" buildpack
-      Then the secrets.yml values are available in the app
-
     Scenario: Ruby offline buildpack integration
       When I push a "ruby" app with the "offline" buildpack
       Then the secrets.yml values are available in the app
 
-    Scenario: Java offline buildpack integration
-      When I push a "java" app with the "offline" buildpack
-      Then the secrets.yml values are available in the app
-
-#    # The online buildpack tests are only valid if the latest commits
-#    # are push to the Github remote branch.
-    Scenario: Python online buildpack integration
-      When I push a "python" app with the "online" buildpack
-      Then the secrets.yml values are available in the app
-
     Scenario: Ruby online buildpack integration
       When I push a "ruby" app with the "online" buildpack
-      Then the secrets.yml values are available in the app
-
-    Scenario: Java online buildpack integration
-      When I push a "java" app with the "online" buildpack
       Then the secrets.yml values are available in the app

--- a/tests/integration/features/integration.feature
+++ b/tests/integration/features/integration.feature
@@ -14,10 +14,28 @@ Feature: Integrations Tests for remote TAS foundation
       Given I create an org and space
       And I install the buildpack
 
+    Scenario: Python offline buildpack integration
+      When I push a "python" app with the "offline" buildpack
+      Then the secrets.yml values are available in the app
+
     Scenario: Ruby offline buildpack integration
       When I push a "ruby" app with the "offline" buildpack
       Then the secrets.yml values are available in the app
 
+    Scenario: Java offline buildpack integration
+      When I push a "java" app with the "offline" buildpack
+      Then the secrets.yml values are available in the app
+
+    # The online buildpack tests are only valid if the latest commits
+    # are push to the Github remote branch.
+    Scenario: Python online buildpack integration
+      When I push a "python" app with the "online" buildpack
+      Then the secrets.yml values are available in the app
+
     Scenario: Ruby online buildpack integration
       When I push a "ruby" app with the "online" buildpack
+      Then the secrets.yml values are available in the app
+
+    Scenario: Java online buildpack integration
+      When I push a "java" app with the "online" buildpack
       Then the secrets.yml values are available in the app

--- a/tests/integration/features/step_definitions/integration_steps.rb
+++ b/tests/integration/features/step_definitions/integration_steps.rb
@@ -24,7 +24,7 @@ When('I push a {string} app with the {string} buildpack') do |language, buildpac
     else
       create_offline_app_manifest
     end
-    ShellSession.execute("cf push #{@app_name} --random-route")
+    ShellSession.execute("cf push #{@app_name} --random-route; cf logs #{@app_name}")
   end
 end
 

--- a/tests/integration/features/step_definitions/integration_steps.rb
+++ b/tests/integration/features/step_definitions/integration_steps.rb
@@ -24,7 +24,7 @@ When('I push a {string} app with the {string} buildpack') do |language, buildpac
     else
       create_offline_app_manifest
     end
-    ShellSession.execute("cf push #{@app_name} --random-route; cf logs #{@app_name}")
+    ShellSession.execute("cf push #{@app_name} --random-route; cf logs #{@app_name} --recent")
   end
 end
 

--- a/tests/retrieve-secrets/README.md
+++ b/tests/retrieve-secrets/README.md
@@ -49,7 +49,7 @@ environment, then  assert upon the output. BATS offers the `$output` variable, w
 contains the output from the previous command executed using the `run` prefix.
 
 ### `stop`
-Removes existing docker-compose containers
+Removes existing Docker Compose environment
 
 ### Configuration
 

--- a/tests/retrieve-secrets/docker-compose.yml
+++ b/tests/retrieve-secrets/docker-compose.yml
@@ -1,7 +1,8 @@
 version: '2.1'
 services:
   mock-conjur-env-builder:
-    build: ""
+    build:
+      context: .
     volumes:
       - .:/mock-conjur-env
       - ../../tmp/vendor:/pkg

--- a/tests/retrieve-secrets/docker-compose.yml
+++ b/tests/retrieve-secrets/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.1'
 services:
   mock-conjur-env-builder:
     build:

--- a/tests/retrieve-secrets/start
+++ b/tests/retrieve-secrets/start
@@ -10,13 +10,13 @@ mkdir -p temp_clone_dir
 git clone https://github.com/ztombol/bats-support temp_clone_dir/bats-support
 git clone https://github.com/ztombol/bats-assert temp_clone_dir/bats-assert
 
-docker-compose build
-docker-compose run --rm mock-conjur-env-builder
+docker compose build
+docker compose run --rm mock-conjur-env-builder
 
 echo "Starting tests for 0001_retrieve-secrets.sh..."
 
 # Uncomment when running locally
-# docker-compose run --rm tester --formatter tap ./test
+# docker compose run --rm tester --formatter tap ./test
 
 # Comment out when running locally
-docker-compose run --rm tester --formatter junit ./test
+docker compose run --rm tester --formatter junit ./test

--- a/tests/retrieve-secrets/stop
+++ b/tests/retrieve-secrets/stop
@@ -4,7 +4,7 @@ function finish {
   echo 'Removing environment...'
 
   rm -rf temp_clone_dir
-  docker-compose down -v
+  docker compose down -v
 }
 
 finish


### PR DESCRIPTION
### Desired Outcome

Fix Jenkins pipeline by using Docker Compose v2

### Implemented Changes

Replaces calls to `docker-compose` with `docker compose`

### Connected Issue/Story

CyberArk internal issue ID: CNJR-2127

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
